### PR TITLE
Update engines and files config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ This changelog format is largely based on [Keep A Changelog](https://keepachange
 
 #### 🔨 Chores & Documentation
 
+## [0.1.2] - 2022-05-01
+
+#### 🔨 Chores & Documentation
+
+- Add `files` config to pjson, removes unnecessary files from published package
+- Update node `engines` config to allow for `^16` and `^18`
+
 ## [0.1.1] - 2022-05-01
 
 #### 🐛 Bug Fixes

--- a/README.md
+++ b/README.md
@@ -133,5 +133,3 @@ Distributed under the `MIT` License. See `LICENSE` for more information.
 `1`: J.R.R. Tolkien, 1954. Mostly.
 
 `2`: [Software Engineering At Google](https://abseil.io/resources/swe_at_google.2.pdf) - Winters, Manshreck and Wright, 2020, p. 341
-
-`3`: Winters et al, 2020, p. 342

--- a/package.json
+++ b/package.json
@@ -1,16 +1,17 @@
 {
   "name": "@wayfair/one-version",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Opinionated Monorepo Dependency Management CLI",
   "bin": "src/index.js",
   "main": "src/index.js",
   "engines": {
-    "node": "^14"
+    "node": "^14 || ^16 || ^18"
   },
   "repository": "git@github.com:wayfair/one-version.git",
   "author": "finn-orsini <orsini.seraphina@gmail.com>",
   "license": "MIT",
   "private": false,
+  "files": ["src/**/*.js", "!src/**/*.test.js"],
   "scripts": {
     "test": "jest",
     "lint": "eslint src/**/*.js",


### PR DESCRIPTION
<!-- Please check the contributing guide before entering PRs: https://github.com/wayfair/one-version/blob/main/CONTRIBUTING.md -->

## Description

- Expands `engines` config to allow for node 16 and 18
- Partial solution for https://github.com/wayfair/one-version/issues/9. 

Previous publish pack was: 

```
npm notice package size:  22.6 kB
npm notice unpacked size: 45.6 kB
```

Updated pack is: 

```
npm notice package size:  6.7 kB
npm notice unpacked size: 18.1 kB
```




## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe)
