### PR TITLE
Exclude fixtures from package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ This changelog format is largely based on [Keep A Changelog](https://keepachange
 
 #### 🔨 Chores & Documentation
 
+## [0.1.3] - 2022-05-03
+
+#### 🔨 Chores & Documentation
+
+- Remove fixtures dir from published package
+
 ## [0.1.2] - 2022-05-01
 
 #### 🔨 Chores & Documentation

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "finn-orsini <orsini.seraphina@gmail.com>",
   "license": "MIT",
   "private": false,
-  "files": ["src/**/*.js", "!src/**/*.test.js"],
+  "files": ["src/**/*.js", "!src/**/*.test.js", "!src/__fixtures__/**/*"],
   "scripts": {
     "test": "jest",
     "lint": "eslint src/**/*.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wayfair/one-version",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Opinionated Monorepo Dependency Management CLI",
   "bin": "src/index.js",
   "main": "src/index.js",


### PR DESCRIPTION
## Description

Ignores `__fixtures__` dir in `files` to remove it from the published package

Resolves #9 

```
npm notice
npm notice 📦  @wayfair/one-version@0.1.3
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 1.6kB src/check.js
npm notice 883B  src/pnpm/check.js
npm notice 615B  src/yarn/check.js
npm notice 402B  src/shared/constants.js
npm notice 1.3kB src/format-output.js
npm notice 387B  src/pnpm/get-workspaces.js
npm notice 368B  src/yarn/get-workspaces.js
npm notice 708B  src/index.js
npm notice 4.8kB src/shared/util.js
npm notice 894B  package.json
npm notice 967B  CHANGELOG.md
npm notice 3.7kB README.md
npm notice === Tarball Details ===
npm notice name:          @wayfair/one-version
npm notice version:       0.1.3
npm notice filename:      wayfair-one-version-0.1.3.tgz
npm notice package size:  6.6 kB
npm notice unpacked size: 17.6 kB
npm notice shasum:        99a5a73e89b02254d722e6a8871aa11fd1cea683
npm notice integrity:     sha512-yr5fFr/BAP+1u[...]OoGhlhVN+zPIA==
npm notice total files:   13
npm notice
wayfair-one-version-0.1.3.tgz
```

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (Chore: package optimization)
