### PR TITLE
Support Package Manager in Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This changelog format is largely based on [Keep A Changelog](https://keepachange
 
 #### 🚀 New Features & Enhancements
 
+- Support setting a package manager in the config file
+
 #### 🐛 Bug Fixes
 
 #### 🔨 Chores & Documentation

--- a/README.md
+++ b/README.md
@@ -97,15 +97,28 @@ prettier
 
 The behavior of `@wayfair/one-version` can be configured by a `one-version.config.json` at the root of the repository.
 
-The only configuration this currently supports is an object of dependency `overrides`. This may be useful while performing major upgrades.
+### Supported config options:
 
-```js
+#### overrides (optional, object)
 
+This may be useful while performing major upgrades. Overrides lets workspaces opt out of the one-version rule.
+
+#### packageManager (optional, string)
+
+This is used to specify the package manager for the workspace. If the `-p` or `--packageManager` argument is included in the command __it will take precedence__ over this value.
+
+Supported values: `pnpm`, `yarn`
+
+
+### Examples:
+
+```json
 "overrides": {
-  dependency: {
-    versionSpecifier: [workspaceA, workspaceB]
+  "dependency": {
+    "versionSpecifier": ["workspaceA", "workspaceB"]
   }
-}
+},
+"packageManager": "pnpm"
 ```
 
 For example, the below config will allow `app-A` and `lib-L` to specify `react@^16.9`, even if the rest of the repo specifies `react@^17`.

--- a/src/__tests__/check.test.js
+++ b/src/__tests__/check.test.js
@@ -5,8 +5,12 @@ const {
 } = require("../shared/constants");
 
 const packageManager = "fake-package-manager";
+const otherPackageManager = "other-package-manager";
 
-const mockGetConfig = () => ({ overrides: {} });
+const mockGetConfig = () => ({
+  overrides: {},
+  packageManager: otherPackageManager,
+});
 const mockGetMissingPackageApi = () => {};
 
 describe("one-version: check", () => {
@@ -45,5 +49,32 @@ describe("one-version: check", () => {
         prettify: () => {},
       });
     }).toThrow(FAILED_CHECK_ERROR);
+  });
+
+  it("-p, --packageManager flags take precedence over the config value", () => {
+    const getCheckApi = jest.fn();
+
+    expect(() => {
+      check({
+        packageManager,
+        getConfig: mockGetConfig,
+        getCheckApi,
+      });
+    }).toThrow(`${NO_CHECK_API_ERROR} ${packageManager}`);
+
+    expect(getCheckApi).toHaveBeenCalledWith(packageManager);
+  });
+
+  it("use the config specified package manager if no flag is used", () => {
+    const getCheckApi = jest.fn();
+
+    expect(() => {
+      check({
+        getConfig: mockGetConfig,
+        getCheckApi,
+      });
+    }).toThrow(`${NO_CHECK_API_ERROR} ${otherPackageManager}`);
+
+    expect(getCheckApi).toHaveBeenCalledWith(otherPackageManager);
   });
 });

--- a/src/check.js
+++ b/src/check.js
@@ -22,15 +22,16 @@ const getCheckPackageApi = (packageManager) => {
 };
 
 const check = ({
-  packageManager,
+  packageManager: packageManagerFlag,
   getConfig = parseConfig,
   getCheckApi = getCheckPackageApi,
   prettify = format,
 } = {}) => {
+  const { overrides, packageManager: packageManagerConfig } = getConfig();
+  const packageManager = packageManagerFlag || packageManagerConfig;
+
   const checkApi = getCheckApi(packageManager);
   if (checkApi) {
-    const { overrides } = getConfig();
-
     const { duplicateDependencies } = checkApi({
       overrides,
     });

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ program
   .description(
     "Verify that only one version of each dependency exists in a monorepo"
   )
-  .option("-p, --packageManager <type>", "package manager", "pnpm")
+  .option("-p, --packageManager <type>", "package manager")
   .action(({ packageManager }) => {
     try {
       check({ packageManager });


### PR DESCRIPTION
## Description

Support setting the package manager in the one-version config file.

Resolves https://github.com/wayfair/one-version/issues/7

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
