### PR TITLE
Refactor Workspace Utils

### DIFF
--- a/src/check.js
+++ b/src/check.js
@@ -3,30 +3,23 @@ Enforcing only one version of any direct dependency is specified in the repo.
 Note: Currently enforces the specifications match exactly, i.e. `^17` != `17`.
 */
 const chalk = require("chalk");
-const { parseConfig, detectPackageManager } = require("./shared/util");
+const {
+  parseConfig,
+  detectPackageManager,
+  getPackageDeps,
+  transformDependencies,
+  findDuplicateDependencies,
+} = require("./shared/util");
 const { format } = require("./format-output");
-const { checkYarn, checkBerry } = require("./yarn/check");
-const { checkPnpm } = require("./pnpm/check");
 const {
   UNABLE_TO_DETECT_PACKAGE_MANAGER_ERROR,
   FAILED_CHECK_ERROR,
-  NO_CHECK_API_ERROR,
 } = require("./shared/constants");
-
-const PACKAGE_MANGER_API = {
-  pnpm: checkPnpm,
-  yarn: checkYarn,
-  berry: checkBerry,
-};
-
-const getCheckPackageApi = (packageManager) => {
-  return PACKAGE_MANGER_API[packageManager];
-};
+const getWorkspaces = require("./get-workspaces");
 
 const check = ({
   getPackageManager = detectPackageManager,
   getConfig = parseConfig,
-  getCheckApi = getCheckPackageApi,
   prettify = format,
 } = {}) => {
   const { overrides } = getConfig();
@@ -36,31 +29,30 @@ const check = ({
     throw new Error(UNABLE_TO_DETECT_PACKAGE_MANAGER_ERROR);
   }
 
-  const checkApi = getCheckApi(packageManager);
-  if (checkApi) {
-    const { duplicateDependencies } = checkApi({
-      overrides,
-    });
+  const workspaces = getWorkspaces(packageManager);
+  const packageDeps = workspaces.map(({ path }) => getPackageDeps(path));
+  const dependenciesByNameAndVersion = transformDependencies(packageDeps);
+  const duplicateDependencies = findDuplicateDependencies(
+    dependenciesByNameAndVersion,
+    overrides
+  );
 
-    if (duplicateDependencies.length > 0) {
-      console.log(
-        chalk.dim("You shall not pass!\n"),
-        chalk.reset(
-          "🚫 One Version Rule Failure - found multiple versions of the following dependencies:\n"
-        ),
-        prettify(duplicateDependencies)
-      );
-
-      throw new Error(FAILED_CHECK_ERROR);
-    }
-
+  if (duplicateDependencies.length > 0) {
     console.log(
-      chalk.dim("My preciousss\n"),
-      chalk.reset("✨ One Version Rule Success - found no version conflicts!")
+      chalk.dim("You shall not pass!\n"),
+      chalk.reset(
+        "🚫 One Version Rule Failure - found multiple versions of the following dependencies:\n"
+      ),
+      prettify(duplicateDependencies)
     );
-  } else {
-    throw new Error(`${NO_CHECK_API_ERROR} ${packageManager}`);
+
+    throw new Error(FAILED_CHECK_ERROR);
   }
+
+  console.log(
+    chalk.dim("My preciousss\n"),
+    chalk.reset("✨ One Version Rule Success - found no version conflicts!")
+  );
 };
 
 module.exports = {

--- a/src/get-workspaces.js
+++ b/src/get-workspaces.js
@@ -1,0 +1,88 @@
+const { execSync } = require("child_process");
+const path = require("path");
+const { NO_CHECK_API_ERROR } = require("./shared/constants");
+
+function getWorkspacesPNPM() {
+  /**
+   * @type {Array<{
+   *   name: string;
+   *   path: string; // absolute path
+   *   private: boolean;
+   *   version?: string;
+   * }>}
+   */
+  const workspaces = JSON.parse(
+    execSync(`pnpm list -r --json --depth -1`, {
+      encoding: "utf8",
+    })
+  );
+
+  // filter out any extra info, only return name and path
+  return workspaces.map(({ name, path }) => ({ name, path }));
+}
+
+function getWorkspacesYarnClassic(cwd) {
+  /**
+   * @type {{
+   *   [name: string]: {
+   *     location: string; // relative path
+   *     workspaceDependencies: string[];
+   *     mismatchedWorkspaceDependencies: string[]
+   *   }
+   * }}
+   */
+  const workspaces = JSON.parse(
+    execSync("yarn --silent workspaces info", { stdio: "pipe" }).toString()
+  );
+
+  // Yarn Classic does not include the root package.
+  const rootPackageJSONPath = path.join(cwd, "package.json");
+  const rootPackageJSON = require(rootPackageJSONPath);
+
+  return [
+    {
+      name: rootPackageJSON.name,
+      path: rootPackageJSONPath,
+    },
+    ...Object.entries(workspaces).map(([name, { location }]) => ({
+      name,
+      path: path.join(cwd, location),
+    })),
+  ];
+}
+
+function getWorkspacesYarnBerry(cwd) {
+  // http://ndjson.org/
+  const ndJSONWorkspaces = execSync("yarn workspaces list --json", {
+    stdio: "pipe",
+  }).toString();
+
+  /**
+   * @type {Array<{
+   *   name: string;
+   *   location: string; // relative path
+   * }>}
+   */
+  const workspaces = ndJSONWorkspaces
+    .replace(/\n*$/, "") // strip out trailing new line
+    .split("\n") // split on new line
+    .map((str) => JSON.parse(str)); // parse each workspace
+
+  return workspaces.map(({ location, name }) => ({
+    name,
+    path: path.join(cwd, location),
+  }));
+}
+
+module.exports = function getWorkspaces(packageManager) {
+  switch (packageManager) {
+    case "pnpm":
+      return getWorkspacesPNPM();
+    case "yarn":
+      return getWorkspacesYarnClassic();
+    case "berry":
+      return getWorkspacesYarnBerry();
+    default:
+      throw new Error(`${NO_CHECK_API_ERROR} ${packageManager}`);
+  }
+};

--- a/src/get-workspaces.js
+++ b/src/get-workspaces.js
@@ -21,7 +21,7 @@ function getWorkspacesPNPM() {
   return workspaces.map(({ name, path }) => ({ name, path }));
 }
 
-function getWorkspacesYarnClassic(cwd) {
+function getWorkspacesYarnClassic(cwd = process.cwd()) {
   /**
    * @type {{
    *   [name: string]: {
@@ -51,7 +51,7 @@ function getWorkspacesYarnClassic(cwd) {
   ];
 }
 
-function getWorkspacesYarnBerry(cwd) {
+function getWorkspacesYarnBerry(cwd = process.cwd()) {
   // http://ndjson.org/
   const ndJSONWorkspaces = execSync("yarn workspaces list --json", {
     stdio: "pipe",

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -26,9 +26,9 @@ const getPackageDeps = (packageRoot) => {
   const packageContents = readFileSync(path.join(packageRoot, "package.json"), {
     encoding: "utf8",
   });
-  const { name, peerDependencies, devDependencies, dependencies } =
+  const { name, peerDependencies, devDependencies, dependencies, resolutions } =
     JSON.parse(packageContents);
-  return { name, peerDependencies, devDependencies, dependencies };
+  return { name, peerDependencies, devDependencies, dependencies, resolutions };
 };
 
 /**


### PR DESCRIPTION
<!-- Please check the contributing guide before entering PRs: https://github.com/wayfair/one-version/blob/main/CONTRIBUTING.md -->

## Description

<!-- Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to related issues, other PRs, or technical references. -->

Note: this is incomplete, want to get thoughts before I clean up and add tests.

Currently we split the `check` APIs which abstract workspace extraction. This makes it mildly difficult to add checks (see https://github.com/wayfair/one-version/issues/24) without extracting workspaces twice or duplicating across check APIs.

I think we can just bifurcate the workspace extraction across package managers, have that return a uniform object. Then operate checks directly on that.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)
