### PR TITLE
Refactor check algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This changelog format is largely based on [Keep A Changelog](https://keepachange
 #### 🔨 Chores & Documentation
 
 - Refactored check api to unify across package managers
+- Refactored check to normalize dependencies to simplify duplicate check logic
 
 ## [0.3.0] - 2022-06-27
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
   "author": "finn-orsini <orsini.seraphina@gmail.com>",
   "license": "MIT",
   "private": false,
-  "files": ["src/**/*.js", "!src/**/*.test.js", "!src/__fixtures__/**/*"],
+  "files": [
+    "src/**/*.js",
+    "!src/**/*.test.js",
+    "!src/__fixtures__/**/*"
+  ],
   "scripts": {
     "test": "jest",
     "lint": "eslint src/**/*.js",
@@ -27,6 +31,7 @@
   },
   "dependencies": {
     "chalk": "^4",
-    "commander": "^9.1"
+    "commander": "^9.1",
+    "uuid": "^9.0.0"
   }
 }

--- a/src/check/dependency-util.js
+++ b/src/check/dependency-util.js
@@ -79,11 +79,12 @@ const getDependenciesByVersion = (dependenciesById) => {
   );
 };
 
-const removeOverrides = ({ dependenciesById = {}, overrides = {} }) => {
+const removeOverrides = ({ dependenciesById = {}, overrides = {} } = {}) => {
   // If we have overrides, remove them from the dependencies list
   if (Object.keys(overrides).length > 0) {
     return Object.entries(dependenciesById).reduce((acc, [id, dep]) => {
       const versionOverrides = overrides?.[dep.packageName] || {};
+
       if (
         versionOverrides[dep.version] &&
         versionOverrides[dep.version].includes(dep.consumerName)
@@ -118,7 +119,7 @@ const getRuleViolations = ({ dependenciesById, overrides }) => {
   );
 
   return Object.entries(packagesWithMultipleVersions).map(
-    ([package, versions]) => ({ name: package, versions })
+    ([name, versions]) => ({ name, versions })
   );
 };
 

--- a/src/check/format-output.js
+++ b/src/check/format-output.js
@@ -59,7 +59,6 @@ const format = (packages, dependenciesById) => {
   return packages
     .map(({ name, versions }) => {
       const str = chalk.cyanBright.underline(name);
-      console.log(str);
 
       const versionsStr = Object.entries(versions)
         .map(([version, dependencyIds]) => {

--- a/src/check/index.js
+++ b/src/check/index.js
@@ -57,8 +57,6 @@ const check = ({
     overrides,
   });
 
-  console.log(duplicateDependencies);
-
   if (duplicateDependencies.length > 0) {
     console.log(
       chalk.dim("You shall not pass!\n"),

--- a/src/check/index.js
+++ b/src/check/index.js
@@ -18,24 +18,16 @@ const {
 
 const {
   getDependenciesById,
-  // getDependenciesByVersion,
-  // findDuplicateDependencies,
+
   getRuleViolations,
 } = require("./dependency-util");
-
-const _getDuplicateDependencies = ({ workspaceDependencies, overrides }) => {
-  //  console.log(ruleViolations);
-  // const d = getDependenciesByVersion(dependenciesById);
-  // console.log(d);
-  //return findDuplicateDependencies(dependenciesByNameAndVersion, overrides);
-};
 
 const check = ({
   getPackageManager = detectPackageManager,
   getConfig = parseConfig,
   prettify = format,
   getWorkspaces = getWorkspacesForPackageManager,
-  getDuplicateDependencies = _getDuplicateDependencies,
+  getDuplicateDependencies = getRuleViolations,
 } = {}) => {
   const { overrides } = getConfig();
 
@@ -52,7 +44,7 @@ const check = ({
 
   const dependenciesById = getDependenciesById(workspaceDependencies);
 
-  const duplicateDependencies = getRuleViolations({
+  const duplicateDependencies = getDuplicateDependencies({
     dependenciesById,
     overrides,
   });

--- a/src/check/index.js
+++ b/src/check/index.js
@@ -17,15 +17,17 @@ const {
 } = require("../shared");
 
 const {
-  transformDependencies,
-  findDuplicateDependencies,
+  getDependenciesById,
+  // getDependenciesByVersion,
+  // findDuplicateDependencies,
+  getRuleViolations,
 } = require("./dependency-util");
 
 const _getDuplicateDependencies = ({ workspaceDependencies, overrides }) => {
-  const dependenciesByNameAndVersion = transformDependencies(
-    workspaceDependencies
-  );
-  return findDuplicateDependencies(dependenciesByNameAndVersion, overrides);
+  //  console.log(ruleViolations);
+  // const d = getDependenciesByVersion(dependenciesById);
+  // console.log(d);
+  //return findDuplicateDependencies(dependenciesByNameAndVersion, overrides);
 };
 
 const check = ({
@@ -48,10 +50,14 @@ const check = ({
     getPackageDeps(path)
   );
 
-  const duplicateDependencies = getDuplicateDependencies({
-    workspaceDependencies,
+  const dependenciesById = getDependenciesById(workspaceDependencies);
+
+  const duplicateDependencies = getRuleViolations({
+    dependenciesById,
     overrides,
   });
+
+  console.log(duplicateDependencies);
 
   if (duplicateDependencies.length > 0) {
     console.log(
@@ -59,7 +65,7 @@ const check = ({
       chalk.reset(
         "🚫 One Version Rule Failure - found multiple versions of the following dependencies:\n"
       ),
-      prettify(duplicateDependencies)
+      prettify(duplicateDependencies, dependenciesById)
     );
 
     throw new Error(FAILED_CHECK_ERROR);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2507,6 +2507,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"


### PR DESCRIPTION
<!-- Please check the contributing guide before entering PRs: https://github.com/wayfair/one-version/blob/main/CONTRIBUTING.md -->

## Description

Refactors one version check. 
Simplifies check logic by creating a map of unique ids -> dependencies, doing the check logic on ids, and only getting dep info again to display. 
The check is now simpler and operates on simpler data structures. A bit of complexity moved into display logic, but I would prefer it there anyway.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)
