### PR TITLE
Drop Node 14 support

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,28 +10,34 @@ on: # Rebuild any PRs and main branch changes
 jobs:
 
   install-node-modules:
-    name: Install Dependencies
+    name: Install Dependencies - Node ${{ matrix.node }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ 16, 18, 20 ]
 
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: ${{ matrix.node }}
           cache: yarn
       - name: Validate cache
         run: yarn install --immutable
 
   test:
-    name: Run Jest Tests
+    name: Run Jest Tests - Node ${{ matrix.node }}
     runs-on: ubuntu-latest
     needs: install-node-modules
+    strategy:
+      matrix:
+        node: [ 16, 18, 20 ]
 
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: ${{ matrix.node }}
           cache: yarn
       - name: install
         run: yarn install --immutable
@@ -39,15 +45,18 @@ jobs:
         run: yarn test
 
   lint:
-    name: Run Lints
+    name: Run Lints - Node ${{ matrix.node }}
     runs-on: ubuntu-latest
     needs: install-node-modules
+    strategy:
+      matrix:
+        node: [ 16, 18, 20 ]
 
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: ${{ matrix.node }}
           cache: yarn
       - name: install
         run: yarn install --immutable
@@ -57,15 +66,18 @@ jobs:
         run: yarn lint:md
 
   prettier:
-    name: Check Formatting
+    name: Check Formatting - Node ${{ matrix.node }}
     runs-on: ubuntu-latest
     needs: install-node-modules
+    strategy:
+      matrix:
+        node: [ 16, 18, 20 ]
 
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: ${{ matrix.node }}
           cache: yarn
       - name: install
         run: yarn install --immutable

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -45,18 +45,15 @@ jobs:
         run: yarn test
 
   lint:
-    name: Run Lints - Node ${{ matrix.node }}
+    name: Run Lints
     runs-on: ubuntu-latest
     needs: install-node-modules
-    strategy:
-      matrix:
-        node: [ 16, 18, 20 ]
 
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 18
           cache: yarn
       - name: install
         run: yarn install --immutable
@@ -66,18 +63,15 @@ jobs:
         run: yarn lint:md
 
   prettier:
-    name: Check Formatting - Node ${{ matrix.node }}
+    name: Check Formatting
     runs-on: ubuntu-latest
     needs: install-node-modules
-    strategy:
-      matrix:
-        node: [ 16, 18, 20 ]
 
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 18
           cache: yarn
       - name: install
         run: yarn install --immutable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - run: yarn
       - run: yarn test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - run: yarn
       - run: yarn test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ This changelog format is largely based on [Keep A Changelog](https://keepachange
 
 #### 🔨 Chores & Documentation
 
+## [0.5.0] - 2023-06-05
+
+#### 💥 Breaking Changes
+
+- Drop support for Node 14 (#43)
+
 ## [0.4.0] - 2023-02-15
 
 #### 🚀 New Features & Enhancements

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "bin": "src/index.js",
   "main": "src/index.js",
   "engines": {
-    "node": "^14 || ^16 || ^18"
+    "node": "^16 || ^18 || ^20"
   },
   "repository": "git@github.com:wayfair/one-version.git",
   "author": "finn-orsini <orsini.seraphina@gmail.com>",


### PR DESCRIPTION
<!-- Please check the contributing guide before entering PRs: https://github.com/wayfair/one-version/blob/main/CONTRIBUTING.md -->

## Description

- Removing Node 14 support as it is now end-of-life.
- Adding Node 20 to `engines`
- Adding version matrix to CI with Node 16, 18, 20

Resolves #43 

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
